### PR TITLE
Try HTMLAudioElement but failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ const id2vo = idolid => (idolid ^ 0x1042fc).toString(16)+"10442d16ab.mp3";
 
 ```
 //追加情報。
-// + "10442216ab.mp3" (use=4,index=1)  -> 名前(体言止め)
+// + "10442116ab.mp3" (use=4,index=1)  -> 名前(体言止め)
 // + "10442216ab.mp3" (use=4,index=2)  -> 名前＋です
 // + "10442c16ab.mp3" (use=4,index=12) -> タイトルコール/ソロ用
 // + "10442d16ab.mp3" (use=4,index=13) -> タイトルコール/ユニット用

--- a/quiz.htm
+++ b/quiz.htm
@@ -31,15 +31,15 @@ let arIdoldatas = [];
 let divLog = null;
 
 class tIdol {
-	constructor( _cid, _name, _type, _voice ){
-		this.cid = _cid;      //ID
-		this.name = _name;    //名前
-		this.type = _type;    //属性
-		this.voice = _voice;  //担当声優
+	constructor( _argobj ){
+		this.cid = _argobj["chara_id"];      //ID
+		this.name = _argobj["name"];    //名前
+		this.type = _argobj["type"];    //属性
+		this.voice = _argobj["voice"];  //担当声優
 		this.bufvoice = null; //音声 as デコード済みAudioData
 		this.ourlicon = null; //画像 as objectURL
 		this.imgelmnt = NEW_TAG("img");
-		this.imgelmnt.alt = _name + ( _voice ? `(cv. ${_voice})` : "" );
+		this.imgelmnt.alt = this.name + ( this.voice ? `(cv. ${this.voice})` : "" );
 		this.btnelmnt = NEW_TAG("button");
 		this.btnelmnt.appendChild( this.imgelmnt );
 		this.btnelmnt.onclick = this.onIconButton;
@@ -121,7 +121,7 @@ async function asyncFetchResources() {
 			const resic = await fetch(urlic);
 			if( resic.status === 200 ){ //画像もOK
 				//新しいobjを作ってグローバル配列に追加
-				let objIdol = new tIdol(objrslt["chara_id"], objrslt["name"], objrslt["type"] , objrslt["voice"]);
+				let objIdol = new tIdol(objrslt);
 				objIdol.setVoiceByResponse(resvo);
 				objIdol.setIconByResponse(resic);
 				arIdoldatas.push(objIdol);

--- a/quiz.htm
+++ b/quiz.htm
@@ -27,41 +27,67 @@ const gAudioCtx = new (window.AudioContext || window.webkitAudioContext)();
 // Webkit/blink系ブラウザは接頭辞が必要、Safariは「window.」をつけないと動かない
 const gURL = window.URL || window.webkitURL; //URLも同様らしいのでそうしておく
 
+const hostStarlightDB = "https://starlight.kirara.ca/";
+const pathCharList = "/api/v1/list/char_t?keys=chara_id";
+const pathCharDetail = "/api/v1/char_t/";
+//URLインターフェースを利用して引数を安全にURL化(さもなくば例外を投げる)
+const urlFirstRequest = new gURL(pathCharList,hostStarlightDB);
+const urlVirtualRequest = new gURL( pathCharDetail, hostStarlightDB );
+
 let arIdoldatas = [];
 let divLog = null;
 
 class tIdol {
 	constructor( _argobj ){
-		this.cid = _argobj["chara_id"];      //ID
+		this.cid = _argobj["chara_id"]; //ID
 		this.name = _argobj["name"];    //名前
 		this.type = _argobj["type"];    //属性
 		this.voice = _argobj["voice"];  //担当声優
-		this.bufvoice = null; //音声 as デコード済みAudioData
-		this.ourlicon = null; //画像 as objectURL
-		this.imgelmnt = NEW_TAG("img");
-		this.imgelmnt.alt = this.name + ( this.voice ? `(cv. ${this.voice})` : "" );
-		this.btnelmnt = NEW_TAG("button");
-		this.btnelmnt.appendChild( this.imgelmnt );
-		this.btnelmnt.onclick = this.onIconButton;
-		this.btnelmnt.owner = this; //buttonからこのクラス自体にアクセスできるように
+
+		//初期化中にのみ使うもの
+		const id2vo = ch => `/va2/${ (this.cid ^ 0x1042fc).toString(16) }10442${ch}16ab.mp3`;
+		const urlIcon = new gURL( _argobj["icon_image_ref"], urlVirtualRequest ).href;
+		const urlTitle1 = new gURL( id2vo("c"), urlIcon ).href;
+		//本家ソースちら見した限り、音声は画像と同じサーバにあるらしい。
+
+		//アイドル個人の情報のvoiceが空文字列ではない＝タイトルコールがある「かもしれない」。
+		//例えば2017年の「恋が咲く季節」イベントの時(だと思われる)、この曲を歌うアイドルのCV 5名分 が反映されたものの、
+		//タイトルコール実装はカード報酬となった2名にとどまっている。
+		//タイトルコールが存在するかは個人情報JSONに現れないので直接音声ファイルのURLを叩いてみる。
+
+		// H TML I mage E lement の略
+		this.HIEicon = NEW_TAG("img");
+		this.HIEicon.owner = this; //このクラス自体にアクセスできるように
+		this.HIEicon.alt = this.name + ( this.voice ? `(cv. ${this.voice})` : "" );
+		this.HIEicon.onload = this.onOkayCallback;
+		this.HIEicon.onerror = this.onErrorCallback;
+		this.HIEicon.src = urlIcon;
+
+		// H TML A udio E lement の略
+		this.HAEtitle1 = NEW_TAG("audio");
+		this.HAEtitle1.owner = this;
+		this.HAEtitle1.oncanplaythrough = this.onOkayCallback; //最後まで再生できる状態になった
+		this.HAEtitle1.onerror = this.onErrorCallback;
+		this.HAEtitle1.src = urlTitle1;
 	}
-	setVoiceByResponse( _res ){
-		_res.arrayBuffer().then( e=>{
-			return gAudioCtx.decodeAudioData(e);
-		} ).then( e=>{
-			this.bufvoice = e;
-			this.btnelmnt.disabled = false;
-		} ).catch( e=>{
-			//ArrayBuffer変換失敗も、デコード失敗も。
-			this.bufvoice = null;
-			this.btnelmnt.disabled = true;
-		} );
+
+	//リソース系共通・読み込み成功時コールバック：thisはイベント対象となったHTMLElement
+	onOkayCallback(){ this.owner.postResult( this, true ); }
+	//リソース系共通・読み込み失敗時コールバック：thisはイベント対象となったHTMLElement
+	onErrorCallback(){ this.owner.postResult( this, false ); }
+	//リソース系共通・読み込み結果処理コールバック
+	postResult( _elmTgt, _bSuccess ){
+		console.log(`[${_bSuccess?"OK":"NG"}] ${this.name} <- ${_elmTgt.src}`);
+		//コールバックをクリアする
+		if( _elmTgt.onload ){ _elmTgt.onload = null; }
+		if( _elmTgt.onerror ){ _elmTgt.onerror = null; }
+		if( _elmTgt.oncanplaythrough ){ _elmTgt.oncanplaythrough = null; }
 	}
-	setIconByResponse( _res ){
-		_res.blob().then( e=>{
-			this.imgelmnt.src = this.ourlicon = gURL.createObjectURL(e);
-		}, e=>{this.ourlicon = null;} );
-	}
+
+	get isIconReady(){ return this.HIEicon.naturalHeight > 0; }
+	get isAudioReady(){ return this.HAEtitle1.readyState === HTMLMediaElement.HAVE_ENOUGH_DATA; }
+
+/*
 	playVoice( _dest, _timing ){
 		if( ! this.bufvoice ) return false;
 
@@ -76,6 +102,7 @@ class tIdol {
 	onIconButton(){
 		this.owner.playVoice( gAudioCtx.destination, gAudioCtx.currentTime );
 	}
+*/
 }
 
 // ++非同期関数++ 問い合わせてレスポンスのJSONをオブジェクトに変換して返す。次の関数でのみ使う
@@ -86,13 +113,11 @@ async function asyncFetchAndStrip( url ) {
 
 // ++非同期関数++ リソースの読み出し
 async function asyncFetchResources() {
-	//URLインターフェースを利用して引数を安全にURL化(さもなくば例外を投げる)
-	const firstRequestURL = new gURL("https://starlight.kirara.ca/api/v1/list/char_t?keys=chara_id");
-	let arrslt = await asyncFetchAndStrip(firstRequestURL);
+	let arrslt = await asyncFetchAndStrip(urlFirstRequest);
 	//最初の結果を利用して次に呼び出すURLを構築
 	let strCharIds = "";
 	for( const s of arrslt ){ strCharIds += (strCharIds.length>0 ? `,${s["chara_id"]}` : s["chara_id"]); }
-	let secondRequestURL = new gURL(`/api/v1/char_t/${strCharIds}`, firstRequestURL);
+	let secondRequestURL = new gURL(pathCharDetail+strCharIds, urlFirstRequest);
 	arrslt = await asyncFetchAndStrip(secondRequestURL);
 
 	const elmfukol = NEW_TAG("div");
@@ -103,39 +128,36 @@ async function asyncFetchResources() {
 	let cnt = 0;
 	for( let idx = 0 ; idx < arrslt.length ; idx++  ){
 		let objrslt = arrslt[idx];
-		//アイドル個人の情報のvoiceが空文字列ではない＝タイトルコールがある「かもしれない」。
-		//例えば2017年の「恋が咲く季節」イベントの時(だと思われる)、この曲を歌うアイドルのCV 5名分 が反映されたものの、
-		//タイトルコール実装はカード報酬となった2名にとどまっている。
-		//タイトルコールが存在するかは個人情報JSONに現れないので直接音声ファイルのURLを叩いてみる。
 
 		if( ! objrslt["voice"] ) continue;
 		//先に音声の所在を確認し、成功したら画像を取り寄せる、の順。
 		//URLを相対から絶対に変換しておく
-		const id2vo = id => "/va2/"+(id ^ 0x1042fc).toString(16)+"10442d16ab.mp3";
-		const urlic = new gURL( objrslt["icon_image_ref"], secondRequestURL ).href;
-		const urlvo = new gURL( id2vo( objrslt["chara_id"] ), urlic ).href; //音声は画像と同じサーバにあるらしい。本家ソースちら見した限り。
-		//即fetchしてステータスを見る
-		let resvo = await fetch(urlvo).catch( e=>{console.log("動作には支障ありません。");} ); //fetchのerrorは(try-catchと同様)、prms.catchでまるっと処理してしまえる
-		if( resvo && resvo.status === 200 ){
+/*		const id2vo = id => "/va2/"+(id ^ 0x1042fc).toString(16)+"10442d16ab.mp3";
+mov		const urlic = new gURL( objrslt["icon_image_ref"], secondRequestURL ).href;
+-ed		const urlvo = new gURL( id2vo( objrslt["chara_id"] ), urlic ).href; //音声は画像と同じサーバにあるらしい。本家ソースちら見した限り。
+*/		//即fetchしてステータスを見る
+//		let resvo = await fetch(urlvo).catch( e=>{console.log("動作には支障ありません。");} ); //fetchのerrorは(try-catchと同様)、prms.catchでまるっと処理してしまえる
+//		if( resvo && resvo.status === 200 ){
 			//音声があった！
-			const resic = await fetch(urlic);
-			if( resic.status === 200 ){ //画像もOK
+//			const resic = await fetch(urlic);
+//			if( resic.status === 200 ){ //画像もOK
 				//新しいobjを作ってグローバル配列に追加
 				let objIdol = new tIdol(objrslt);
-				objIdol.setVoiceByResponse(resvo);
-				objIdol.setIconByResponse(resic);
 				arIdoldatas.push(objIdol);
 				//グリッドシステムに表示ブロックを入れ込む。
 				let p = NEW_TAG("div");
 				p.className = "imascg-"+objIdol.type;
-				p.appendChild( objIdol.btnelmnt );
+				p.appendChild( objIdol.HIEicon );
+				p.appendChild( NEW_TAG("br") );
+				p.appendChild( objIdol.HAEtitle1 );
+				objIdol.HAEtitle1.controls = true;
 				p.appendChild( NEW_TAG("br") );
 				let q = NEW_TAG("span");
 				q.textContent = `#${++cnt}-${idx}/${arrslt.length}[${objIdol.cid}]`;
 				p.appendChild( q );
 				elmfukol.insertBefore(p, elmfukol.firstChild);
-			}
-		}
+//			}
+//		}
 	}
 	let p = NEW_TAG("p");
 	p.textContent = `読み取り完了。全 ${arrslt.length} 人中ボイス設定ありは ${cnt} 人でした。`;


### PR DESCRIPTION
HTMLAudioElement を使ってみたかったが、音源再生タイミングをリアルタイムに制御できないことに気づいたのでその手を使うことは諦めました。

`MediaElementAudioSourceNode = AudioContext.createMediaElementSource( HTMLAudioElement )` でオーディオノードの連鎖に組み込むことは出来ますが、依然再生は HTMLAudioElement 主導なので、タイミングを計算して再生(要するに audioSourceNode.start( timing ) 的な)処理を仕込むことができないようです。

よって、tIdol初期化引数の変更とそれに伴う音声初期化処理の場所移行を適用します。