### PR TITLE
DB名称を決め打ちに変更

### DIFF
--- a/cachey.js
+++ b/cachey.js
@@ -3,6 +3,7 @@
  * Promise版IndexedDB https://github.com/jakearchibald/idb を使う。
  * オススメは script defer src="https://cdn.rawgit.com/jakearchibald/idb/master/lib/idb.js" の直後にこれをdeferで読み込む。
  */
+
 var cachey = cachey || {
 	/**
 	 * @type{IDBDatabase} 開かれたデータベース
@@ -17,7 +18,7 @@ var cachey = cachey || {
 	 * @return{Promise<Boolean>} Promise<初期化の成否>
 	 */
 	async asyncInit(){
-		return await self.idb.open( nameIDB, 1, upgradeDB=>{
+		return await self.idb.open( "StarlightDB", 1, upgradeDB=>{
 			//****DB更新時処理****
 			switch (upgradeDB.oldVersion) {
 				case 0:

--- a/quiz.htm
+++ b/quiz.htm
@@ -38,7 +38,6 @@ const msgPlzHoldOn = "⌛リソース取得中..."; //PLEASE HOLD ON
 const msgFineFetch = "✅️リソース取得完了。タイトルコール実装済みアイドルは";
 const msgFineFetch2 = "人です。";
 
-const nameIDB = "StarlightDB";
 const hostStarlightDB = "https://starlight.kirara.ca/";
 const pathCharList = "/api/v1/list/char_t?keys=chara_id";
 const pathCharDetail = "/api/v1/char_t/";


### PR DESCRIPTION
現状の「データ種別ごとにObjectStoreを切り替える」ではなく、「データ種別ごとにDBを切り替える」のがいいのか悩んでいた頃の残滓